### PR TITLE
Fix broken name resolution by adding a specific route to the nameserver network on agent start

### DIFF
--- a/properties/tc_config.py
+++ b/properties/tc_config.py
@@ -23,8 +23,11 @@ class Tc_config(Property):
         out2, err1 = pipe.communicate()
         self._iface_nm = str(out2).strip("b'").strip("'")
 
-        # quick hack to facilitate routing between different networks
+        # quick hack to facilitate routing between different networks - these routes are non-persistent!
         cmd = "ip route add 10.0.1.0/24 dev "+self._iface_nm
+        Popen(cmd, shell=True, stdout=sc.PIPE, stderr=sc.PIPE).communicate()
+        # Enable name resolution (default Amazon VPC nameserver is always on NET_BASE_ADDR+2, i.e. 10.0.0.2)
+        cmd = "ip route add 10.0.0.0/24 dev "+self._iface_nm
         Popen(cmd, shell=True, stdout=sc.PIPE, stderr=sc.PIPE).communicate()
         cmd = "ip route add 10.0.0.0/16 dev "+iface
         Popen(cmd, shell=True, stdout=sc.PIPE, stderr=sc.PIPE).communicate()


### PR DESCRIPTION
The agent now adds an additional route `10.0.0.0/24 via eth0` on startup enabling access to Amazons default nameserver (which is at 10.0.0.2). This effectively unhides the nameservers network segment because the rule takes precedence over `10.0.0.0/16 via eth1` due to it being more specific.
See corresponding issue on MockFog-Meta: https://github.com/OpenFogStack/MockFog-Meta/issues/1

This is rather a quick fix because it only works as long as the agent has started and nothing has restarted the network stack since then. It is in line though with the existing implementation...